### PR TITLE
fix(brev-8): fix droplet creation size

### DIFF
--- a/lib/brevityoperations/droplet.py
+++ b/lib/brevityoperations/droplet.py
@@ -44,7 +44,7 @@ def createDroplet(accessToken,dropletName,runOperation,programName,awsAccessKeyI
                                    name=dropletName,
                                    region='nyc3', # New York 2
                                    image='ubuntu-20-04-x64', # Ubuntu 20.04 x64
-                                   size_slug='s-8vcpu-16gb',  # 1GB RAM, 1 vCPU
+                                   size_slug='s-1vcpu-1gb',  # 1GB RAM, 1 vCPU
                                    ssh_keys=keys,
                                    backups=False,
                                    user_data=userData)
@@ -93,7 +93,7 @@ def createDropletManual(accessToken,dropletName,runOperation,programName,awsAcce
                                    name=dropletName,
                                    region='nyc3', # New York 2
                                    image='ubuntu-20-04-x64', # Ubuntu 20.04 x64
-                                   size_slug='s-1vcpu-1gb',  # s-8vcpu-16gb
+                                   size_slug='s-1vcpu-1gb',  # 1GB RAM, 1 vCPU
                                    ssh_keys=keys,
                                    backups=False,
                                    user_data=userData)


### PR DESCRIPTION
# Summary
The size for droplet creation was '**s-8vcpu-16gb**' instead of '**s-1vcpu-1gb**'.

That big of a droplet would increase the cost significantly, so it is best to keep it at the minimal size necessary.

# Ticket #
BREV-8
